### PR TITLE
Releasing docker image for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 
 jobs:
   test:
@@ -32,3 +34,31 @@ jobs:
           -e "BUILD_NAME=$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER"
           concourse-slack-alert-resource:$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
           /opt/resource/out $PWD
+
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF##*/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u arbourd -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            arbourd/concourse-slack-alert-resource:${{ steps.prepare.outputs.tag_name }}
+            arbourd/concourse-slack-alert-resource:latest


### PR DESCRIPTION
Hi

**Package Owner:** Prakriti Chauhan

**PR change Details:**

**$ Patch Details:** Following files has been modified:
.github/workflows/ci.yml: Created a new job publish to release the image for amd64 and arm64 using https://github.com/docker/build-push-action

**$ Testing Detail :**
**Github actions Link** - https://github.com/odidev/concourse-slack-alert-resource/runs/1820414170?check_suite_focus=true
**Dockerhub Link** - https://hub.docker.com/repository/docker/odidev/concourse-slack-alert-resource

**$ PR Description:** Here is my commit message :
Releasing docker image for arm64

Here is my PR description -
The following files have been modified:
Added a new job publish in .github/workflows/ci.yml to release the image for amd64 and arm64 using https://github.com/docker/build-push-action

**$Reviewer:** Pruthvi Teja Reddy

Thanks
Prakriti Chauhan